### PR TITLE
Add phys_torque fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,35 +12,49 @@ Uses the hooks provided by **[BigChat](https://github.com/CFC-Servers/gm_bigchat
 ### Description
 Fixes the on-tick `hudScaler` error spam.
 
+---
+
 ## `swep_remover`
 
 ### Description
 Prevents configured weapon classes to be prevented from loading, such as abusive admin weapons.
+
+---
 
 ## `player_pickup_fix`
 
 ### Description
 Fixes a weird Garry's Mod exploit that happens if a player issues an absurd amount of `Use` commands on a single entity.
 
+---
+
 ## `l4d2_vehicles_fix`
 
 ### Description
 Fixes a silly (but absurdly spammy) `nil` error that occurrs in a popular L4D2 SimfPhys Vehicle Pack (this fix has already been proposed upstream, but the author doesn't appear to want to implement it)
+
+---
 
 ## `net_remover`
 
 ### Description
 Removes certain net messages that are never used or useless for our usecase.
 
+---
+
 ## `disablebloom`
 
 ### Description
 Disables annoying bloom for maps that use bloom.
 
+---
+
 ## `lfs_advert`
 
 ### Description
 Removes the annoying LFS spawn in message
+
+---
 
 ## `spherical`
 
@@ -48,6 +62,13 @@ Removes the annoying LFS spawn in message
 Fixes instant server crashes when trying to init a spherical physics object on an entity that has custom collisions enabled.
 
 _[ref](https://github.com/Facepunch/garrysmod-issues/issues/5535)_
+
+---
+
+## `phys_torque_fix`
+
+### Description
+Players can use `phys_torque`-derived constraints to instantly crash the server. This fix will stop the crashes with no side effects _(probably)_.
 
 # Development
 **Halt!**

--- a/lua/cfc_gmod_scripts/phys_torque_fix/init.lua
+++ b/lua/cfc_gmod_scripts/phys_torque_fix/init.lua
@@ -1,0 +1,13 @@
+local maxScale = 1000000
+local math_min = math.min
+
+local entMeta = FindMetaTable( "Entity" )
+entMeta._GMS_Fire = entMeta._GMS_Fire or entMeta.Fire
+
+function entMeta:Fire( input, param, delay, activator, caller )
+    if self:GetClass() == "phys_torque" and input == "Scale" then
+        param = math_min( maxScale, param )
+    end
+
+    return self:_GMS_Fire( input, param, delay, activator, caller )
+end


### PR DESCRIPTION
Fixes a stinky bug that happens if a `phys_torque` entity (motors) are `Fire`'d with too much `Scale`.

The same setup that would cause the bug before now behaves normally.

Before:
```
Stinky Bug (core dumped)
email debug.log to linux@valvesoftware.com
```

After:
```
[GMS] phys_torque Scale clamped from        9.9999996802857e+38     to      1000000
```