### PR TITLE
Use Starfall instance correctly

### DIFF
--- a/lua/cfc_gmod_scripts/effects_whitelist/sh_init.lua
+++ b/lua/cfc_gmod_scripts/effects_whitelist/sh_init.lua
@@ -15,10 +15,10 @@ hook.Add( "Expression2_CanEffect", "CFC_GmodScripts_EffectWhitelist", function( 
     return deny( ply, name )
 end )
 
-hook.Add( "Starfall_CanEffect", "CFC_GmodScripts_EffectWhitelist", function( name, chip )
+hook.Add( "Starfall_CanEffect", "CFC_GmodScripts_EffectWhitelist", function( name, instance )
     if allowed[name] then return end
 
-    local ply = chip.owner
+    local ply = instance.player
     return deny( ply, name )
 end )
 


### PR DESCRIPTION
The `Starfall_CanEffect` hook passes a Starfall instance, not the chip's entity.