### PR TITLE
Spawn players underground

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # cfc_gmod_scripts
 A disgusting pile of loose-knit, à la carte scripts for Garry's Mod
 
+# Development
+**Halt!**
+Are you **100% sure** your idea doesn't fit better in its own repo, or perhaps another one of our addons?
+Loose-knit script repos like this are in danger of turning into a unmaintainable dumping ground. Please do your best to keep it clean and reasonable.
+
+
+⚠️ The project structure and these rules are subject to change as we add more scripts.
+
+All scripts should follow these rules:
+ - Be contained to a single directory under `lua/cfc_gmod_scripts/`
+ - Have an `init.lua` at the root of their directory
+ - Have a section in this README under the [Included Scripts](#included-scripts) category
+ - Ideally, have a convar to enable/disable them
+
 # Included Scripts:
 
 ## `bigchat_restrictor`
@@ -31,10 +45,13 @@ Fixes a weird Garry's Mod exploit that happens if a player issues an absurd amou
 
 <br>
 
-## `player_spawn_under`
+## `player_spawn_underground`
 
 ### Description
 Puts the player outside of the world when they first spawn, hopefully reducing their initial network strain while their game finishes loading.
+
+### Convar
+**`cfc_gmodscripts_enable_spawn_underground`**
 
 <br>
 
@@ -92,16 +109,3 @@ Prevents players from spam rejoining the server to spam chat messages.
 
 <br>
 
-# Development
-**Halt!**
-Are you **100% sure** your idea doesn't fit better in its own repo, or perhaps another one of our addons?
-Loose-knit script repos like this are in danger of turning into a unmaintainable dumping ground. Please do your best to keep it clean and reasonable.
-
-
-⚠️ The project structure and these rules are subject to change as we add more scripts.
-
-All scripts should follow these rules:
- - Be contained to a single directory under `lua/cfc_gmod_scripts/`
- - Have an `init.lua` at the root of their directory
- - Have a section in this README under the [Included Scripts](#included-scripts) category
- - Ideally, have a convar to enable/disable them

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Fixes a weird Garry's Mod exploit that happens if a player issues an absurd amou
 
 <br>
 
+## `player_spawn_under`
+
+### Description
+Puts the player outside of the world when they first spawn, hopefully reducing their initial network strain while their game finishes loading.
+
+<br>
+
 ## `net_remover`
 
 ### Description

--- a/lua/cfc_gmod_scripts/player_spawn_underground/sv_init.lua
+++ b/lua/cfc_gmod_scripts/player_spawn_underground/sv_init.lua
@@ -1,6 +1,7 @@
 require( "playerload" )
 
 local enable = CreateConVar( "cfc_gmodscripts_spawnin_lag_fixer", "1", FCVAR_ARCHIVE, "Spawn players underground to combat lag" )
+local transmitRate = CreateConVar( "cfc_gmodscripts_spawnin_lag_fixer_transmit_rate", "5", FCVAR_ARCHIVE, "How many entities to transmit per tick" )
 
 local table_remove = table.remove
 local table_insert = table.insert
@@ -13,21 +14,21 @@ local queues = {}
 --- Player queues that need to be processed when they fully load
 local pending = {}
 --- Entities that were spawned by players
-local trackedEnts = {}
+local trackedEnts = ents.GetAll()
 
 -- Main queue processing loop. Processes N items from each queue
 hook.Add( "Think", "SpawnInLagFixer", function()
+    if not enable:GetBool() then return end
     local queueCount = #queues
 
     for q = 1, queueCount do
-        local struct = pending[q]
+        local struct = queues[q]
 
         local ply = struct[1]
-        local queue = struct[2]
+        local plyQueue = struct[2]
 
-        -- Process 10 items from each player's queue
-        for i = 1, 10 do
-            local ent = table_remove( queue )
+        for i = 1, transmitRate:GetInt() do
+            local ent = table_remove( plyQueue )
             if not ent then break end
 
             if Entity_IsValid( ent ) then

--- a/lua/cfc_gmod_scripts/player_spawn_underground/sv_init.lua
+++ b/lua/cfc_gmod_scripts/player_spawn_underground/sv_init.lua
@@ -1,88 +1,54 @@
 require( "playerload" )
 
-local function Deque()
-    local Data = {}
-    local Queue = {}
-
-    local head = 1
-    local tail = 0
-    local size = 0
-
-    function Queue.Push( value )
-        tail = tail + 1
-        Data[tail] = value
-
-        size = size + 1
-    end
-
-    function Queue.Pop()
-        if head > tail then return nil end
-
-        local value = Data[head]
-        Data[head] = nil
-        head = head + 1
-        size = size - 1
-
-        return value
-    end
-
-    function Queue.IsEmpty()
-        return size == 0
-    end
-
-    function Queue.GetSize()
-        return size
-    end
-
-    return Queue
-end
-
-
 local enable = CreateConVar( "cfc_gmodscripts_spawnin_lag_fixer", "1", FCVAR_ARCHIVE, "Spawn players underground to combat lag" )
 
-local plys = {}
-local plyCount = 0
-timer.Create( "SpawnInLagFixer", 1, 0, function()
-    plys = player.GetAll()
-    plyCount = #plys
-end )
-
-local queue = Deque()
-local queue_Push = queue.Push
-local queue_Pop = queue.Pop
-local queue_IsEmpty = queue.IsEmpty
-
+local table_remove = table.remove
+local table_insert = table.insert
 local entMeta = FindMetaTable( "Entity" )
 local Entity_IsValid = entMeta.IsValid
-do
-    local SetPreventTransmit = entMeta.SetPreventTransmit
+local SetPreventTransmit = entMeta.SetPreventTransmit
 
-    hook.Add( "Think", "SpawnInLagFixer", function()
-        if queue_IsEmpty() then return end
+--- Active ent queues for players that have loaded in
+local queues = {}
+--- Player queues that need to be processed when they fully load
+local pending = {}
+--- Entities that were spawned by players
+local trackedEnts = {}
 
+-- Main queue processing loop. Processes N items from each queue
+hook.Add( "Think", "SpawnInLagFixer", function()
+    local queueCount = #queues
+
+    for q = 1, queueCount do
+        local struct = pending[q]
+
+        local ply = struct[1]
+        local queue = struct[2]
+
+        -- Process 10 items from each player's queue
         for i = 1, 10 do
-            local struct = queue_Pop()
-            if not struct then return end
+            local ent = table_remove( queue )
+            if not ent then break end
 
-            local ply = struct[1]
-            local ent = struct[2]
-
-            if ent:IsValid() then
+            if Entity_IsValid( ent ) then
                 SetPreventTransmit( ent, ply, false )
             else
+                -- Always do at least 10 entities for each player if we can
                 i = i - 1
             end
         end
-    end )
-end
+    end
+end )
 
-local trackedEnts = {}
-local table_insert = table.insert
 
+-- On initial spawn, prevent all ents from being transmitted to them
+-- Then track the ents that we stopped transmitting to them
 hook.Add( "PlayerInitialSpawn", "SpawnInLagFixer", function( ply )
     if not enable:GetBool() then return end
 
+    -- While we're looping the tracked ents anyway, we also re-build the list to remove invalid ents
     local newEnts = {}
+    local plyPending = {}
 
     local entCount = #trackedEnts
     for i = 1, entCount do
@@ -90,56 +56,34 @@ hook.Add( "PlayerInitialSpawn", "SpawnInLagFixer", function( ply )
 
         if Entity_IsValid( ent ) then
             table_insert( newEnts, ent )
+            table_insert( plyPending, ent )
+
+            -- TODO: This might need to be queued or something, it'll be laggy
             SetPreventTransmit( ent, ply, true )
         end
     end
+
+    -- These are the ents that we stopped transmitting to them
+    -- When they fully load, we will start transmitting them in batches
+    pending[ply] = plyPending
+
+    -- "passive" validity insurance
+    trackedEnts = newEnts
 end )
 
 
-local pendingEnts = {}
-
-gameevent.Listen( "player_connect" )
-hook.Add( "player_connect", "SpawnInLagFixer", function( data )
-    if not enable:GetBool() then return end
-    local ply = Player( data.userid )
-    pendingEnts[ply] = {}
-end )
-
+--- They fully loaded, now we can queue up their pending ents
 hook.Add( "PlayerFullLoad", "SpawnInLagFixer", function( ply )
     if not enable:GetBool() then return end
 
-    local pending = pendingEnts[ply]
-    local count = #pending
-
-    for i = 1, count do
-        local struct = pending[i]
-        queue_Push( struct )
-    end
-
-    pendingEnts[ply] = nil
+    table_insert( queues, { ply, pending[ply] } )
+    pending[ply] = nil
 end )
 
 local function handleNewEnt( _, model, ent )
     if not enable:GetBool() then return end
     if not ent then ent = model end
-
-    for i = 1, plyCount do
-        local ply = plys[i]
-
-        local struct = { ply, ent }
-        local pending = pendingEnts[ply]
-
-        if pending then
-            -- If they're still loading in, we don't want to start processing their queue yet
-            table_insert( pending, struct )
-        else
-            -- Otherwise, we can just add it to the queue
-            queue_Push( struct )
-        end
-
-        SetPreventTransmit( ent, ply, true )
-        table_insert( trackedEnts, ent )
-    end
+    table_insert( trackedEnts, ent )
 end
 
 hook.Add( "PlayerSpawnedProp", "SpawnInLagFixer", handleNewEnt )

--- a/lua/cfc_gmod_scripts/player_spawn_underground/sv_init.lua
+++ b/lua/cfc_gmod_scripts/player_spawn_underground/sv_init.lua
@@ -1,5 +1,7 @@
 require( "playerload" )
 
+local enable = CreateConVar( "cfc_gmodscripts_enable_spawn_underground", "1", FCVAR_ARCHIVE, "Spawn players underground to combat lag" )
+
 local offset = Vector( 0, 0, 5000 )
 local hookName = "CFC_GmodScripts_PlayerSpawnPosition"
 
@@ -7,6 +9,7 @@ local pendingFirstSpawn = {}
 
 -- Set them below ground for their first spawn
 hook.Add( "PlayerSpawn", hookName, function( ply )
+    if not enable:GetBool() then return end
     if not pendingFirstSpawn[ply] then return end
 
     timer.Simple( 0, function()
@@ -17,6 +20,7 @@ end )
 
 -- Reset their position after they've fully loaded
 hook.Add( "PlayerFullLoad", hookName, function( ply )
+    if not enable:GetBool() then return end
     timer.Simple( 0, function()
         ply:SetPos( ply:GetPos() + offset )
     end )
@@ -24,9 +28,11 @@ end )
 
 -- Create first-spawn queue
 hook.Add( "PlayerInitialSpawn", hookName, function( ply )
+    if not enable:GetBool() then return end
     pendingFirstSpawn[ply] = true
 end )
 
 hook.Add( "PlayerDisconnected", hookName, function( ply )
+    if not enable:GetBool() then return end
     pendingFirstSpawn[ply] = nil
 end )

--- a/lua/cfc_gmod_scripts/player_spawn_underground/sv_init.lua
+++ b/lua/cfc_gmod_scripts/player_spawn_underground/sv_init.lua
@@ -1,38 +1,149 @@
 require( "playerload" )
 
-local enable = CreateConVar( "cfc_gmodscripts_enable_spawn_underground", "1", FCVAR_ARCHIVE, "Spawn players underground to combat lag" )
+local function Deque()
+    local Data = {}
+    local Queue = {}
 
-local offset = Vector( 0, 0, 5000 )
-local hookName = "CFC_GmodScripts_PlayerSpawnPosition"
+    local head = 1
+    local tail = 0
+    local size = 0
 
-local pendingFirstSpawn = {}
+    function Queue.Push( value )
+        tail = tail + 1
+        Data[tail] = value
 
--- Set them below ground for their first spawn
-hook.Add( "PlayerSpawn", hookName, function( ply )
-    if not enable:GetBool() then return end
-    if not pendingFirstSpawn[ply] then return end
+        size = size + 1
+    end
 
-    timer.Simple( 0, function()
-        ply:SetPos( ply:GetPos() - offset )
-        pendingFirstSpawn[ply] = nil
+    function Queue.Pop()
+        if head > tail then return nil end
+
+        local value = Data[head]
+        Data[head] = nil
+        head = head + 1
+        size = size - 1
+
+        return value
+    end
+
+    function Queue.IsEmpty()
+        return size == 0
+    end
+
+    function Queue.GetSize()
+        return size
+    end
+
+    return Queue
+end
+
+
+local enable = CreateConVar( "cfc_gmodscripts_spawnin_lag_fixer", "1", FCVAR_ARCHIVE, "Spawn players underground to combat lag" )
+
+local plys = {}
+local plyCount = 0
+timer.Create( "SpawnInLagFixer", 1, 0, function()
+    plys = player.GetAll()
+    plyCount = #plys
+end )
+
+local queue = Deque()
+local queue_Push = queue.Push
+local queue_Pop = queue.Pop
+local queue_IsEmpty = queue.IsEmpty
+
+local entMeta = FindMetaTable( "Entity" )
+local Entity_IsValid = entMeta.IsValid
+do
+    local SetPreventTransmit = entMeta.SetPreventTransmit
+
+    hook.Add( "Think", "SpawnInLagFixer", function()
+        if queue_IsEmpty() then return end
+
+        for i = 1, 10 do
+            local struct = queue_Pop()
+            if not struct then return end
+
+            local ply = struct[1]
+            local ent = struct[2]
+
+            if ent:IsValid() then
+                SetPreventTransmit( ent, ply, false )
+            else
+                i = i - 1
+            end
+        end
     end )
+end
+
+local trackedEnts = {}
+local table_insert = table.insert
+
+hook.Add( "PlayerInitialSpawn", "SpawnInLagFixer", function( ply )
+    if not enable:GetBool() then return end
+
+    local newEnts = {}
+
+    local entCount = #trackedEnts
+    for i = 1, entCount do
+        local ent = trackedEnts[i]
+
+        if Entity_IsValid( ent ) then
+            table_insert( newEnts, ent )
+            SetPreventTransmit( ent, ply, true )
+        end
+    end
 end )
 
--- Reset their position after they've fully loaded
-hook.Add( "PlayerFullLoad", hookName, function( ply )
+
+local pendingEnts = {}
+
+gameevent.Listen( "player_connect" )
+hook.Add( "player_connect", "SpawnInLagFixer", function( data )
     if not enable:GetBool() then return end
-    timer.Simple( 0, function()
-        ply:SetPos( ply:GetPos() + offset )
-    end )
+    local ply = Player( data.userid )
+    pendingEnts[ply] = {}
 end )
 
--- Create first-spawn queue
-hook.Add( "PlayerInitialSpawn", hookName, function( ply )
+hook.Add( "PlayerFullLoad", "SpawnInLagFixer", function( ply )
     if not enable:GetBool() then return end
-    pendingFirstSpawn[ply] = true
+
+    local pending = pendingEnts[ply]
+    local count = #pending
+
+    for i = 1, count do
+        local struct = pending[i]
+        queue_Push( struct )
+    end
+
+    pendingEnts[ply] = nil
 end )
 
-hook.Add( "PlayerDisconnected", hookName, function( ply )
+local function handleNewEnt( _, model, ent )
     if not enable:GetBool() then return end
-    pendingFirstSpawn[ply] = nil
-end )
+    if not ent then ent = model end
+
+    for i = 1, plyCount do
+        local ply = plys[i]
+
+        local struct = { ply, ent }
+        local pending = pendingEnts[ply]
+
+        if pending then
+            -- If they're still loading in, we don't want to start processing their queue yet
+            table_insert( pending, struct )
+        else
+            -- Otherwise, we can just add it to the queue
+            queue_Push( struct )
+        end
+
+        SetPreventTransmit( ent, ply, true )
+        table_insert( trackedEnts, ent )
+    end
+end
+
+hook.Add( "PlayerSpawnedProp", "SpawnInLagFixer", handleNewEnt )
+hook.Add( "PlayerSpawnedSENT", "SpawnInLagFixer", handleNewEnt )
+hook.Add( "PlayerSpawnedRagdoll", "SpawnInLagFixer", handleNewEnt )
+hook.Add( "PlayerSpawnedVehicle", "SpawnInLagFixer", handleNewEnt )
+hook.Add( "PlayerSpawnedSWEP", "SpawnInLagFixer", handleNewEnt )

--- a/lua/cfc_gmod_scripts/player_spawn_underground/sv_init.lua
+++ b/lua/cfc_gmod_scripts/player_spawn_underground/sv_init.lua
@@ -1,0 +1,32 @@
+require( "playerload" )
+
+local offset = Vector( 0, 0, 5000 )
+local hookName = "CFC_GmodScripts_PlayerSpawnPosition"
+
+local pendingFirstSpawn = {}
+
+-- Set them below ground for their first spawn
+hook.Add( "PlayerSpawn", hookName, function( ply )
+    if not pendingFirstSpawn[ply] then return end
+
+    timer.Simple( 0, function()
+        ply:SetPos( ply:GetPos() - offset )
+        pendingFirstSpawn[ply] = nil
+    end )
+end )
+
+-- Reset their position after they've fully loaded
+hook.Add( "PlayerFullLoad", hookName, function( ply )
+    timer.Simple( 0, function()
+        ply:SetPos( ply:GetPos() + offset )
+    end )
+end )
+
+-- Create first-spawn queue
+hook.Add( "PlayerInitialSpawn", hookName, function( ply )
+    pendingFirstSpawn[ply] = true
+end )
+
+hook.Add( "PlayerDisconnected", hookName, function( ply )
+    pendingFirstSpawn[ply] = nil
+end )

--- a/lua/includes/modules/playerload.lua
+++ b/lua/includes/modules/playerload.lua
@@ -2,7 +2,7 @@
 
 local loadQueue = {}
 
-hook.Add( "PlayerInitialSpawn", "GM_FullLoadSetup", function(ply)
+hook.Add( "PlayerInitialSpawn", "GM_FullLoadSetup", function( ply )
     loadQueue[ply] = true
 end )
 

--- a/lua/includes/modules/playerload.lua
+++ b/lua/includes/modules/playerload.lua
@@ -1,0 +1,17 @@
+-- https://github.com/CFC-Servers/gm_playerload
+
+local loadQueue = {}
+
+hook.Add( "PlayerInitialSpawn", "GM_FullLoadSetup", function(ply)
+    loadQueue[ply] = true
+end )
+
+hook.Add( "SetupMove", "GM_FullLoadTrigger", function( ply, _, cmd )
+    if not loadQueue[ply] then return end
+    if cmd:IsForced() then return end
+
+    loadQueue[ply] = nil
+    ProtectedCall( function()
+        hook.Run( "PlayerFullLoad", ply )
+    end )
+end )


### PR DESCRIPTION
Spawns players underground as soon as possible to help reduce their network strain.

We might want to delay the part that puts them back above ground by a second or two?