### PR TITLE
Fix blocked effect spam prints for non-owner players

### DIFF
--- a/lua/cfc_gmod_scripts/effects_whitelist/sh_init.lua
+++ b/lua/cfc_gmod_scripts/effects_whitelist/sh_init.lua
@@ -20,12 +20,12 @@ end )
 hook.Add( "Starfall_CanEffect", "CFC_GmodScripts_EffectWhitelist", function( name, instance )
     if allowed[name] then return end
 
-    local owner = instance.owner
-    if owner:IsAdmin() then return end
+    local ply = instance.player
+    if ply:IsAdmin() then return end
 
     -- Only send the error message to the Starfall owner
-    if instance.player == owner then
-        return deny( owner, name )
+    if ply == LocalPlayer() then
+        return deny( ply, name )
     end
 
     return false

--- a/lua/cfc_gmod_scripts/effects_whitelist/sh_init.lua
+++ b/lua/cfc_gmod_scripts/effects_whitelist/sh_init.lua
@@ -20,10 +20,15 @@ end )
 hook.Add( "Starfall_CanEffect", "CFC_GmodScripts_EffectWhitelist", function( name, instance )
     if allowed[name] then return end
 
-    local ply = instance.player
-    if ply:IsAdmin() then return end
+    local owner = instance.owner
+    if owner:IsAdmin() then return end
 
-    return deny( ply, name )
+    -- Only send the error message to the Starfall owner
+    if instance.player == owner then
+        return deny( owner, name )
+    end
+
+    return false
 end )
 
 GmodScripts_EffectWhitelist = {


### PR DESCRIPTION
Fixes a situation where players will randomly get this message because someone else's clientside starfall is using blocked effects

![image](https://github.com/CFC-Servers/cfc_gmod_scripts/assets/7936439/7c7ca71a-f035-4201-a500-bf744c29455c)
