### PR TITLE
Add no_teamchat

### DIFF
--- a/lua/cfc_gmod_scripts/no_teamchat/sv_noteamchat.lua
+++ b/lua/cfc_gmod_scripts/no_teamchat/sv_noteamchat.lua
@@ -1,0 +1,12 @@
+if engine.ActiveGamemode() ~= "sandbox" then return end -- Other gamemodes will actually have a use for teamchat
+
+local ranks = {
+    user = true,
+    regular = true
+}
+
+hook.Add( "PlayerCanSeePlayersChat", "GmodScripts_PublicTeamChat", function( _text, team, _listener, speaker )
+    local usergroup = speaker:GetUserGroup()
+    if not ranks[usergroup] then return end
+    if team then return true end
+end )


### PR DESCRIPTION
Makes it so that user / regular teamchat is public for everyone, every day there are users that only use teamchat and then get sad because nobody responds to them.