### PR TITLE
Wiremod entspawn logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,16 @@ Fixes a bug where using Proper Clipping on a dropped weapon would crash the serv
 <br>
 
 
+## `wire_entspawn_alert`
+
+### Description
+- **Server**
+Prints ULX-like logs when a player spawns a Wiremod entity (either with the toolgun or AdvDupe2)
+
+
+### Config
+- `cfc_gmodscripts_wire_entspawn_alert`
+
+<br>
+
+

--- a/lua/cfc_gmod_scripts/wire_entspawn_alert/sv_init.lua
+++ b/lua/cfc_gmod_scripts/wire_entspawn_alert/sv_init.lua
@@ -1,0 +1,87 @@
+local enabled = GmodScripts.MakeToggle( "wire_sent_spawn_alert", "Make wire log all SENT spawns", true )
+
+hook.Add( "PreGamemodeLoaded", "CFC_GmodScripts_LoadWireSpawnStub", function()
+    local logger = ulx and ulx.logSpawn or print
+
+    local log = function( ply, entClass )
+        if IsValid( ply ) then
+            logger( string.format( "%s<%s> spawned sent %s", ply:Nick(), ply:SteamID(), entClass ) )
+        else
+            logger( string.format( "SENT was spawned without a valid owner:", entClass ) )
+        end
+    end
+
+    local replaceDupeFunctions = {}
+
+    local wrapper = function( original )
+        local wrapped = function( ply, ... )
+            local result = original( ply, ... )
+            if not enabled:GetBool() then
+                return result
+            end
+
+            if isentity( result ) then
+                local entClass = result:GetClass()
+                log( ply, entClass )
+            else
+                print( ply, "unknown", result )
+            end
+
+            return result
+        end
+
+        replaceDupeFunctions[original] = wrapped
+        return wrapped
+    end
+
+    local dupeClasses = duplicator.EntityClasses
+
+    local originalMakeWireEnt = WireLib.MakeWireEnt
+    WireLib.MakeWireEnt = wrapper( originalMakeWireEnt )
+    _G.MakeWireMotorController = wrapper( _G.MakeWireMotorController )
+    _G.MakeWireHydraulicController = wrapper( _G.MakeWireHydraulicController )
+    _G.MakeWireExpression2 = wrapper( _G.MakeWireExpression2 )
+
+    -- Special case for gmod_wire_gate so we can figure out what action it is
+    do
+        local original = WireLib.MakeWireGate
+        local gateStub = function( ply, pos, ang, model, action, ... )
+            local result = original( ply, pos, ang, model, action, ... )
+            if not enabled:GetBool() then
+                return result
+            end
+
+            if isentity( result ) then
+                local entClass = "gmod_wire_gate(" .. action .. ")"
+                log( ply, entClass )
+            end
+
+            return result
+        end
+
+        -- This fun bit of nonsense lets us stub MakeWireGate (which calls MakeWireEnt) and print which gate was spawned but without duplicate prints.
+        -- For example, if I spawn an Entity gate, MakeWireGate wrapper prints: gmod_wire_gate(rd_entity), but then it calls the wrapped MakeWireEnt and prints: gmod_wire_gate again
+        -- This code prevents that by allowing MakeWireGate to call the original MakeWireEnt
+        local specialWireLib = setmetatable( { MakeWireEnt = originalMakeWireEnt }, { __index = WireLib } )
+        setfenv( original, setmetatable( { WireLib = specialWireLib }, { __index = _G } ) )
+
+        WireLib.MakeWireGate = gateStub
+        dupeClasses.gmod_wire_gate.Func = gateStub
+    end
+
+    -- Overwrite specific dupe functions that use local functions
+    dupeClasses.sent_deployableballoons.Func = wrapper( dupeClasses.sent_deployableballoons.Func )
+    dupeClasses.gmod_wire_egp.Func = wrapper( dupeClasses.gmod_wire_egp.Func )
+    dupeClasses.gmod_wire_egp_hud.Func = wrapper( dupeClasses.gmod_wire_egp_hud.Func )
+    dupeClasses.gmod_wire_egp_emitter.Func = wrapper( dupeClasses.gmod_wire_egp_emitter.Func )
+
+    -- I can't figure out how to load at the right time, so this loops over all dupe functions and 
+    -- replaces them with the wrapped version if they exist (we stub the global func after they already registered with duplicator idk)
+    -- If you can find a hook that runs after autorun, but before weapons/entities/sents, then use that and remove this
+    for _, data in pairs( dupeClasses ) do
+        local wrapped = replaceDupeFunctions[data.Func]
+        if wrapped then
+            data.Func = wrapped
+        end
+    end
+end )


### PR DESCRIPTION
Without:
```
[AdvDupe2Notify]	Pasting...
Phatso<STEAM_0:0:21170873> spawned ragdoll models/gibs/fast_zombie_legs.mdl
Phatso<STEAM_0:0:21170873> spawned vehicle models/nova/chair_plastic01.mdl
Phatso<STEAM_0:0:21170873> spawned sent weapon_357
Phatso<STEAM_0:0:21170873> spawned NPC npc_monk
Phatso<STEAM_0:0:21170873> spawned model models/props_c17/concrete_barrier001a.mdl
Phatso<STEAM_0:0:21170873> spawned effect models/props_lab/chess.mdl
[AdvDupe2Notify]	Finished Pasting!
```

With:
```
[AdvDupe2Notify]	Pasting...
Phatso<STEAM_0:0:21170873> spawned ragdoll models/gibs/fast_zombie_legs.mdl
Phatso<STEAM_0:0:21170873> spawned vehicle models/nova/chair_plastic01.mdl
Phatso<STEAM_0:0:21170873> spawned sent weapon_357
Phatso<STEAM_0:0:21170873> spawned NPC npc_monk
Phatso<STEAM_0:0:21170873> spawned sent gmod_wire_consolescreen
Phatso<STEAM_0:0:21170873> spawned model models/props_c17/concrete_barrier001a.mdl
Phatso<STEAM_0:0:21170873> spawned effect models/props_lab/chess.mdl
Phatso<STEAM_0:0:21170873> spawned sent gmod_wire_gate(rd_entity)
Phatso<STEAM_0:0:21170873> spawned sent gmod_wire_expression2
[AdvDupe2Notify]	Finished Pasting!
```

Toggleable live with the convar.

I spent a long time trying to find the best way to do this, so I decided to just pick a strategy and go with it. I'm not married to this solution, but it does appear to work.
