### PR TITLE
Whitelist effect: HL1GaussWallImpact2

### DIFF
--- a/lua/cfc_gmod_scripts/effects_whitelist/sh_init.lua
+++ b/lua/cfc_gmod_scripts/effects_whitelist/sh_init.lua
@@ -83,5 +83,6 @@ GmodScripts.EffectWhitelist = {
     selection_indicator = true,
     selection_ring = true,
     wheel_indicator = true,
+    HL1GaussWallImpact2 = true,
 }
 allowed = GmodScripts.EffectWhitelist


### PR DESCRIPTION
It's the "orange orbs" that fly off from walls when shooting with the HL1 Tau Cannon.