### PR TITLE
Whitelist Glide effects

### DIFF
--- a/lua/cfc_gmod_scripts/effects_whitelist/sh_init.lua
+++ b/lua/cfc_gmod_scripts/effects_whitelist/sh_init.lua
@@ -85,6 +85,24 @@ GmodScripts.EffectWhitelist = {
     selection_ring = true,
     wheel_indicator = true,
     HL1GaussWallImpact2 = true,
-    glide_explosion = true
+
+    glide_explosion = true,
+    glide_afterburner_flame = true,
+    glide_afterburner = true,
+    glide_boat_foam = true,
+    glide_boat_propeller = true,
+    glide_boat_splash = true,
+    glide_damaged_engine = true,
+    glide_damaged_exhaust = true,
+    glide_exhaust = true,
+    glide_fire = true,
+    glide_flare = true,
+    glide_metal_impact = true,
+    glide_missile = true,
+    glide_projectile = true,
+    glide_tank_cannon = true,
+    glide_tire_roll = true,
+    glide_tire_slip_forward = true,
+    glide_tracer = true,
 }
 allowed = GmodScripts.EffectWhitelist


### PR DESCRIPTION
Adds all currently available effects from Glide to the whitelist.

`glide_explosion`
`glide_afterburner_flame`
`glide_afterburner`
`glide_boat_foam`
`glide_boat_propeller`
`glide_boat_splash`
`glide_damaged_engine`
`glide_damaged_exhaust`
`glide_exhaust`
`glide_fire`
`glide_flare`
`glide_metal_impact`
`glide_missile`
`glide_projectile`
`glide_tank_cannon`
`glide_tire_roll`
`glide_tire_slip_forward`
`glide_tracer`

I did some testing with Starfall to make sure you couldn't create long-lasting/massive effects (after I added validation to those effects yesterday), and so far it looks good.

Also, here's a demo SF chip to cycle through each effect: [glide_effects.txt](https://github.com/user-attachments/files/22651595/glide_effects.txt)